### PR TITLE
Fix compilation error

### DIFF
--- a/include/tinycolormap.hpp
+++ b/include/tinycolormap.hpp
@@ -48,6 +48,8 @@
 #ifndef TINYCOLORMAP_HPP_
 #define TINYCOLORMAP_HPP_
 
+typedef u_int8_t uint8_t;
+
 #include <cmath>
 #include <array>
 

--- a/include/tinycolormap.hpp
+++ b/include/tinycolormap.hpp
@@ -48,10 +48,9 @@
 #ifndef TINYCOLORMAP_HPP_
 #define TINYCOLORMAP_HPP_
 
-typedef u_int8_t uint8_t;
-
 #include <cmath>
 #include <array>
+#include <cstdint>
 
 #if defined(TINYCOLORMAP_WITH_EIGEN)
 #include <Eigen/Core>


### PR DESCRIPTION
This commit fixes a compilation error related to the use of `uint8_t`, while some systems use `u_int8_t`.

Build system: GNU 10.1, Linux (Centos 7.x).