### PR TITLE
Little fixes for Visual C++ use

### DIFF
--- a/include/tinycolormap.hpp
+++ b/include/tinycolormap.hpp
@@ -50,6 +50,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <algorithm>
 
 #if defined(TINYCOLORMAP_WITH_EIGEN)
 #include <Eigen/Core>
@@ -59,7 +60,7 @@
 #include <QColor>
 #endif
 
-#if defined(TINYCOLORMAP_WITH_QT5) and defined(TINYCOLORMAP_WITH_EIGEN)
+#if defined(TINYCOLORMAP_WITH_QT5) && defined(TINYCOLORMAP_WITH_EIGEN)
 #include <QImage>
 #include <QString>
 #endif
@@ -138,7 +139,7 @@ namespace tinycolormap
     inline Color GetCividisColor(double x);
     inline Color GetGithubColor(double x);
 
-#if defined(TINYCOLORMAP_WITH_QT5) and defined(TINYCOLORMAP_WITH_EIGEN)
+#if defined(TINYCOLORMAP_WITH_QT5) && defined(TINYCOLORMAP_WITH_EIGEN)
     inline QImage CreateMatrixVisualization(const Eigen::MatrixXd& matrix);
     inline void ExportMatrixVisualization(const Eigen::MatrixXd& matrix, const std::string& path);
 #endif
@@ -170,7 +171,7 @@ namespace tinycolormap
         inline double QuantizeArgument(double x, unsigned int num_levels)
         {
             // Clamp num_classes to range [1, 255].
-            num_levels = std::max(1u, std::min(num_levels, 255u));
+            num_levels = (std::max)(1u, (std::min)(num_levels, 255u));
 
             const double interval_length = 255.0 / num_levels;
 
@@ -2165,7 +2166,7 @@ namespace tinycolormap
         return internal::CalcLerp(x, data);
     }
 
-#if defined(TINYCOLORMAP_WITH_QT5) and defined(TINYCOLORMAP_WITH_EIGEN)
+#if defined(TINYCOLORMAP_WITH_QT5) && defined(TINYCOLORMAP_WITH_EIGEN)
     inline QImage CreateMatrixVisualization(const Eigen::MatrixXd& matrix)
     {
         const int w = matrix.cols();


### PR DESCRIPTION
Hi,

I wanted to offer these changes that allowed me to compile the library in a Visual C++ 2019 environment. I'm not certain, but I believe they should work across environments. 

- #included <algorithm> library for std::max and std::min
- wrapped std::max and std::min in parentheses to avoid conflict with macros from windows.h
- replaced preprocessor operators "and" with "&&"

No obligation to merge, but I thought it might be useful. Thanks for the great library!